### PR TITLE
[EN-13] Current Funding Safe Casting

### DIFF
--- a/exchanges/bitfinex/bitfinex_websocket.go
+++ b/exchanges/bitfinex/bitfinex_websocket.go
@@ -303,6 +303,10 @@ func (b *Bitfinex) wsHandleData(respRaw []byte) error {
 			return nil
 		case wsStatus:
 			statusData := d[1].([]interface{})
+			var safeCurrentFunding float64
+			if statusData[11] != nil {
+				safeCurrentFunding = statusData[11].(float64)
+			}
 			b.Websocket.DataHandler <- &ticker.Ticker{
 				Price: ticker.Price{
 					LastUpdated:  time.Unix(0, int64(statusData[0].(float64))*int64(time.Millisecond)),
@@ -317,7 +321,7 @@ func (b *Bitfinex) wsHandleData(respRaw []byte) error {
 					NextFundingEvtTimestamp: time.Unix(0, int64(statusData[7].(float64))*int64(time.Millisecond)),
 					NextFundingAccrued:      statusData[8].(float64),
 					NextFundingStep:         int(statusData[9].(float64)),
-					CurrentFunding:          statusData[11].(float64),
+					CurrentFunding:          safeCurrentFunding,
 					MarkPrice:               statusData[14].(float64),
 					OpenInterest:            statusData[17].(float64),
 					//ClampMin:                statusData[21].(float64),


### PR DESCRIPTION
-Api returns nil every 8 hours due to current funding being for an 8 hour period
-Adds casting safety to handle panic thrown when casting on nil

-Ran into ws 1006 error codes earlier this week, assumed it was due to passing nil forward
-Was unable to reproduce ws 1006 error code consistently during week of testing, and passing nil
directly didn't trigger errors, so making PR in the meantime.